### PR TITLE
Update doxygen docs styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 docs/doxygen_output
 build/
 navi
+
+# IDE
+.vscode
+.idea

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "doxygen-awesome-css"]
+	path = doxygen-awesome-css
+	url = https://github.com/jothepro/doxygen-awesome-css.git

--- a/docs/doxygen-config
+++ b/docs/doxygen-config
@@ -1357,7 +1357,8 @@ HTML_STYLESHEET        =
 # documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_STYLESHEET  =
+HTML_EXTRA_STYLESHEET  = ../doxygen-awesome-css/doxygen-awesome.css \
+                        ../doxygen-awesome-css/doxygen-awesome-sidebar-only.css
 
 # The HTML_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the HTML output directory. Note
@@ -1688,7 +1689,7 @@ DISABLE_INDEX          = NO
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-GENERATE_TREEVIEW      = NO
+GENERATE_TREEVIEW      = YES
 
 # When both GENERATE_TREEVIEW and DISABLE_INDEX are set to YES, then the
 # FULL_SIDEBAR option determines if the side bar is limited to only the treeview


### PR DESCRIPTION
I genuinely could not read the doxygen docs with the existing styles so I added some styles for it. Since it is a submodule, you would have to use `git clone --recurse-submodules [url]` when cloning. I could alternatively copy the styles to the docs folder but I didn't want to because it's not code written and managed by us.

Old:

<img width="1512" alt="Screenshot 2023-10-22 at 12 51 10 AM" src="https://github.com/UBCAgroBot/Navi/assets/39626451/6be66eed-bd0b-4cfa-9549-bf8db11e33fc">

New:

<img width="1512" alt="Screenshot 2023-10-22 at 12 47 09 AM" src="https://github.com/UBCAgroBot/Navi/assets/39626451/67ce4f3a-b4ef-499f-8fe5-9a5cd0615570">
